### PR TITLE
Upgrade deprecated runtime nodejs14.x

### DIFF
--- a/amplify_code/amplify/#current-cloud-backend/auth/myamplifyapp84642f50/myamplifyapp84642f50-cloudformation-template.yml
+++ b/amplify_code/amplify/#current-cloud-backend/auth/myamplifyapp84642f50/myamplifyapp84642f50-cloudformation-template.yml
@@ -235,7 +235,7 @@ Resources:
             - ' }'
             - '};'
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs16.x
       Timeout: '300'
       Role: !GetAtt 
         - UserPoolClientRole

--- a/amplify_code/amplify/#current-cloud-backend/auth/userPoolGroups/template.json
+++ b/amplify_code/amplify/#current-cloud-backend/auth/userPoolGroups/template.json
@@ -244,7 +244,7 @@
                     }
                 },
                 "Handler": "index.handler",
-                "Runtime": "nodejs14.x",
+                "Runtime": "nodejs16.x",
                 "Timeout": "300",
                 "Role": {
                     "Fn::GetAtt": [

--- a/amplify_code/amplify/backend/auth/myamplifyapp84642f50/myamplifyapp84642f50-cloudformation-template.yml
+++ b/amplify_code/amplify/backend/auth/myamplifyapp84642f50/myamplifyapp84642f50-cloudformation-template.yml
@@ -235,7 +235,7 @@ Resources:
             - ' }'
             - '};'
       Handler: index.handler
-      Runtime: nodejs14.x
+      Runtime: nodejs16.x
       Timeout: '300'
       Role: !GetAtt 
         - UserPoolClientRole

--- a/amplify_code/amplify/backend/auth/userPoolGroups/template.json
+++ b/amplify_code/amplify/backend/auth/userPoolGroups/template.json
@@ -244,7 +244,7 @@
                     }
                 },
                 "Handler": "index.handler",
-                "Runtime": "nodejs14.x",
+                "Runtime": "nodejs16.x",
                 "Timeout": "300",
                 "Role": {
                     "Fn::GetAtt": [

--- a/amplify_code/amplify/backend/awscloudformation/nested-cloudformation-stack.yml
+++ b/amplify_code/amplify/backend/awscloudformation/nested-cloudformation-stack.yml
@@ -224,7 +224,7 @@
 					}
 				},
 				"Handler": "index.handler",
-				"Runtime": "nodejs14.x",
+				"Runtime": "nodejs16.x",
 				"Timeout": "300",
 				"Role": {
 					"Fn::GetAtt": [


### PR DESCRIPTION
CloudFormation templates in aws-end-to-end-iot-amplify-demo have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs14.x). The affected templates have been updated to a supported runtime (nodejs16.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.